### PR TITLE
Only list usernames when checking for user, to stop false positives w…

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: Ensure MySQL user exists
   shell: >
-    (echo "SELECT user, host FROM mysql.user;" | mysql | grep {{ mysql_database_user }})
+    (echo "SELECT user FROM mysql.user;" | mysql | grep {{ mysql_database_user }})
     ||
     (echo "CREATE USER '{{ mysql_database_user }}'@'localhost' IDENTIFIED BY '{{ mysql_database_user_password }}';" | mysql)
 


### PR DESCRIPTION
This fixes a bug where a hostname would match the username, causing the user to never be created. Affects Mercury because mysql adds a `root@mercury` user when installed :/

Fixes the bug from yesterday @hcurotta @johnspicer 